### PR TITLE
dynamic java heap size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,8 @@ RUN chown -R elastico:elastico /var/lib/elasticsearch /etc/elasticsearch /var/lo
 
 VOLUME /var/lib/elasticsearch/data
 
-HEALTHCHECK NONE
-
 EXPOSE 9200 9300
-ENV JAVA_HEAP_SIZE=256
+#ENV JAVA_HEAP_SIZE=256
 
 HEALTHCHECK --interval=5s --retries=3 --timeout=1s CMD curl -s localhost:9200 | jq .version.number | grep -qv null
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -7,6 +7,28 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 program="$1"
 
+if [[ -z "$JAVA_HEAP_SIZE" ]]; then
+  # adjust max heap size to available memory
+  if [[ -f /proc/meminfo ]]; then
+    tmem=$(grep MemTotal /proc/meminfo | awk '{print int($2 * 0.001)}')
+    echo "INFO - system memory is ${tmem}M"
+    if [[ $tmem -lt 1024 ]]; then
+        echo "INFO - set java heap size to floor value"
+        JAVA_HEAP_SIZE=256
+    elif [[ $tmem -lt 4092 ]]; then
+        echo "INFO - set java heap size to ramping value"
+        # 256 to 410
+        JAVA_HEAP_SIZE=$((256 + (tmem - 1024) / 19))
+    else
+        echo "INFO - set java heap size to 10%"
+        JAVA_HEAP_SIZE=$((tmem / 10))
+    fi
+    export JAVA_HEAP_SIZE
+  else
+    echo "WARN - can't read /proc/meminfo, using default java heap size value"
+  fi
+fi
+
 runes=0
 # Drop root privileges if we are running elasticsearch
 # allow the container to be started with `--user`


### PR DESCRIPTION
if not set, the java heap size is set to an appropriate value based on available memory:
up to 1024M: 256M
1024M to 4092M: ramping from 256M to 10% 
4092M+: 10%
